### PR TITLE
[Fix] OpenAI Embedderにdimensions設定不可の場合の対応

### DIFF
--- a/src/jmteb/embedders/openai_embedder.py
+++ b/src/jmteb/embedders/openai_embedder.py
@@ -43,13 +43,15 @@ class OpenAIEmbedder(TextEmbedder):
                 self.dim = dim
 
     def encode(self, text: str | list[str]) -> np.ndarray:
+        kwargs = {"dimensions": self.dim} if self.model != "text-embedding-ada-002" else {}
+        # specifying `dimensions` is not allowed for "text-embedding-ada-002"
         result = np.asarray(
             [
                 data.embedding
                 for data in self.client.embeddings.create(
                     input=text,
                     model=self.model,
-                    dimensions=self.dim,
+                    **kwargs,
                 ).data
             ]
         )

--- a/src/jmteb/embedders/openai_embedder.py
+++ b/src/jmteb/embedders/openai_embedder.py
@@ -33,7 +33,7 @@ class OpenAIEmbedder(TextEmbedder):
         self.client = OpenAI()  # API key written in .env
         assert model in MODEL_DIM.keys(), f"`model` must be one of {list(MODEL_DIM.keys())}!"
         self.model = model
-        if not dim:
+        if not dim or model == "text-embedding-ada-002":
             self.dim = MODEL_DIM[self.model]
         else:
             if dim > MODEL_DIM[self.model]:

--- a/tests/embedders/test_openai.py
+++ b/tests/embedders/test_openai.py
@@ -33,7 +33,8 @@ class MockOpenAIClientEmbedding:
             assert "dimensions" not in kwargs
             dimensions = OUTPUT_DIM
         else:
-            dimensions = kwargs.get("dimensions", OUTPUT_DIM)
+            assert "dimensions" in kwargs
+            dimensions = kwargs.get("dimensions")
         if isinstance(input, str):
             input = [input]
         return MockData(data=[MockEmbedding(embedding=[0.1] * dimensions)] * len(input))

--- a/tests/embedders/test_openai.py
+++ b/tests/embedders/test_openai.py
@@ -28,7 +28,12 @@ class MockEmbedding:
 
 
 class MockOpenAIClientEmbedding:
-    def create(input: str | list[str], model: str, dimensions: int):
+    def create(input: str | list[str], model: str, **kwargs):
+        if model == "text-embedding-ada-002":
+            assert "dimensions" not in kwargs
+            dimensions = OUTPUT_DIM
+        else:
+            dimensions = kwargs.get("dimensions", OUTPUT_DIM)
         if isinstance(input, str):
             input = [input]
         return MockData(data=[MockEmbedding(embedding=[0.1] * dimensions)] * len(input))
@@ -61,6 +66,18 @@ class TestOpenAIEmbedder:
     def test_model_dim(self):
         assert OpenAIEmbedder(model="text-embedding-3-large").dim == 3072
         assert OpenAIEmbedder(model="text-embedding-ada-002").dim == 1536
+
+    def test_ada_002_dim(self):
+        # check that no `dimensions` argument is set for model "text-embedding-ada-002"
+        #   else an assertion error will be raised in MockOpenAIClientEmbedding
+        #   and model "text-embedding-ada-002" has a fixed output dimension
+        embeddings = OpenAIEmbedder(model="text-embedding-ada-002", dim=2 * OUTPUT_DIM).encode("任意のテキスト")
+        assert isinstance(embeddings, np.ndarray)
+        assert embeddings.shape == (OUTPUT_DIM,)
+
+        embeddings = OpenAIEmbedder(model="text-embedding-ada-002", dim=OUTPUT_DIM // 2).encode("任意のテキスト")
+        assert isinstance(embeddings, np.ndarray)
+        assert embeddings.shape == (OUTPUT_DIM,)
 
     def test_dim_over_max(self):
         assert OpenAIEmbedder(dim=2 * OUTPUT_DIM).dim == OUTPUT_DIM


### PR DESCRIPTION
<!-- 
PRを出していただき、ありがとうございます。
base branchを`dev`にするよう、お願いいたします。
-->

## 関連する Issue / PR
N/A

## PR をマージした後の挙動の変化
修正後，text-embedding-ada-002 も正常に動くようにできました。
text-embedding-ada-002 では`dimensions`の設定が不可とされているため，今のままだと下記のエラーが出ています。
```
openai.BadRequestError: Error code: 400 - {'error': {'message': 'This model does not support specifying dimensions.', 'type': 'invalid_request_error', 'param': None, 'code': None}}
```
`dimensions=None`もできないようです。


## 挙動の変更を達成するために行ったこと
本PRでは`dimensions`引数を`model=text-embedding-ada-002`の場合には送らないようにし，`OpenAIEmbedder`内のdimも設定と関わらず1536とします。
これで解消しました。

## 動作確認
- [x] テストが通ることを確認した

<!-- 
## その他
-->