### PR TITLE
[Fix] OpenAIEmbedderにおける長さ超過のインプットテキストの処理

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2585,6 +2585,58 @@ files = [
 ]
 
 [[package]]
+name = "tiktoken"
+version = "0.6.0"
+description = "tiktoken is a fast BPE tokeniser for use with OpenAI's models"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tiktoken-0.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:277de84ccd8fa12730a6b4067456e5cf72fef6300bea61d506c09e45658d41ac"},
+    {file = "tiktoken-0.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9c44433f658064463650d61387623735641dcc4b6c999ca30bc0f8ba3fccaf5c"},
+    {file = "tiktoken-0.6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afb9a2a866ae6eef1995ab656744287a5ac95acc7e0491c33fad54d053288ad3"},
+    {file = "tiktoken-0.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c62c05b3109fefca26fedb2820452a050074ad8e5ad9803f4652977778177d9f"},
+    {file = "tiktoken-0.6.0-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:0ef917fad0bccda07bfbad835525bbed5f3ab97a8a3e66526e48cdc3e7beacf7"},
+    {file = "tiktoken-0.6.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:e095131ab6092d0769a2fda85aa260c7c383072daec599ba9d8b149d2a3f4d8b"},
+    {file = "tiktoken-0.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:05b344c61779f815038292a19a0c6eb7098b63c8f865ff205abb9ea1b656030e"},
+    {file = "tiktoken-0.6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cefb9870fb55dca9e450e54dbf61f904aab9180ff6fe568b61f4db9564e78871"},
+    {file = "tiktoken-0.6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:702950d33d8cabc039845674107d2e6dcabbbb0990ef350f640661368df481bb"},
+    {file = "tiktoken-0.6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e8d49d076058f23254f2aff9af603863c5c5f9ab095bc896bceed04f8f0b013a"},
+    {file = "tiktoken-0.6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:430bc4e650a2d23a789dc2cdca3b9e5e7eb3cd3935168d97d43518cbb1f9a911"},
+    {file = "tiktoken-0.6.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:293cb8669757301a3019a12d6770bd55bec38a4d3ee9978ddbe599d68976aca7"},
+    {file = "tiktoken-0.6.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:7bd1a288b7903aadc054b0e16ea78e3171f70b670e7372432298c686ebf9dd47"},
+    {file = "tiktoken-0.6.0-cp311-cp311-win_amd64.whl", hash = "sha256:ac76e000183e3b749634968a45c7169b351e99936ef46f0d2353cd0d46c3118d"},
+    {file = "tiktoken-0.6.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:17cc8a4a3245ab7d935c83a2db6bb71619099d7284b884f4b2aea4c74f2f83e3"},
+    {file = "tiktoken-0.6.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:284aebcccffe1bba0d6571651317df6a5b376ff6cfed5aeb800c55df44c78177"},
+    {file = "tiktoken-0.6.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0c1a3a5d33846f8cd9dd3b7897c1d45722f48625a587f8e6f3d3e85080559be8"},
+    {file = "tiktoken-0.6.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6318b2bb2337f38ee954fd5efa82632c6e5ced1d52a671370fa4b2eff1355e91"},
+    {file = "tiktoken-0.6.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:1f5f0f2ed67ba16373f9a6013b68da298096b27cd4e1cf276d2d3868b5c7efd1"},
+    {file = "tiktoken-0.6.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:75af4c0b16609c2ad02581f3cdcd1fb698c7565091370bf6c0cf8624ffaba6dc"},
+    {file = "tiktoken-0.6.0-cp312-cp312-win_amd64.whl", hash = "sha256:45577faf9a9d383b8fd683e313cf6df88b6076c034f0a16da243bb1c139340c3"},
+    {file = "tiktoken-0.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7c1492ab90c21ca4d11cef3a236ee31a3e279bb21b3fc5b0e2210588c4209e68"},
+    {file = "tiktoken-0.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e2b380c5b7751272015400b26144a2bab4066ebb8daae9c3cd2a92c3b508fe5a"},
+    {file = "tiktoken-0.6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c9f497598b9f58c99cbc0eb764b4a92272c14d5203fc713dd650b896a03a50ad"},
+    {file = "tiktoken-0.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e65e8bd6f3f279d80f1e1fbd5f588f036b9a5fa27690b7f0cc07021f1dfa0839"},
+    {file = "tiktoken-0.6.0-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:5f1495450a54e564d236769d25bfefbf77727e232d7a8a378f97acddee08c1ae"},
+    {file = "tiktoken-0.6.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:6c4e4857d99f6fb4670e928250835b21b68c59250520a1941618b5b4194e20c3"},
+    {file = "tiktoken-0.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:168d718f07a39b013032741867e789971346df8e89983fe3c0ef3fbd5a0b1cb9"},
+    {file = "tiktoken-0.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:47fdcfe11bd55376785a6aea8ad1db967db7f66ea81aed5c43fad497521819a4"},
+    {file = "tiktoken-0.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:fb7d2ccbf1a7784810aff6b80b4012fb42c6fc37eaa68cb3b553801a5cc2d1fc"},
+    {file = "tiktoken-0.6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1ccb7a111ee76af5d876a729a347f8747d5ad548e1487eeea90eaf58894b3138"},
+    {file = "tiktoken-0.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b2048e1086b48e3c8c6e2ceeac866561374cd57a84622fa49a6b245ffecb7744"},
+    {file = "tiktoken-0.6.0-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:07f229a5eb250b6403a61200199cecf0aac4aa23c3ecc1c11c1ca002cbb8f159"},
+    {file = "tiktoken-0.6.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:432aa3be8436177b0db5a2b3e7cc28fd6c693f783b2f8722539ba16a867d0c6a"},
+    {file = "tiktoken-0.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:8bfe8a19c8b5c40d121ee7938cd9c6a278e5b97dc035fd61714b4f0399d2f7a1"},
+    {file = "tiktoken-0.6.0.tar.gz", hash = "sha256:ace62a4ede83c75b0374a2ddfa4b76903cf483e9cb06247f566be3bf14e6beed"},
+]
+
+[package.dependencies]
+regex = ">=2022.1.18"
+requests = ">=2.26.0"
+
+[package.extras]
+blobfile = ["blobfile (>=2)"]
+
+[[package]]
 name = "tokenizers"
 version = "0.15.2"
 description = ""
@@ -3339,4 +3391,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.8.1,<4.0"
-content-hash = "0a438df085b5f588ae2e896ccf7ae833860690af20528afac6bddc963abf564c"
+content-hash = "7d56cec3404a22872c6960e849559f28c67a024d58b411fb5e30bd8e8c284a6d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ eval-type-backport = "^0.1.3"
 smart-open = "^7.0.1"
 openai = "^1.16.2"
 pytest-mock = "^3.14.0"
+tiktoken = "^0.6.0"
 
 [tool.poetry.group.dev.dependencies]
 black = "^23.11.0"

--- a/src/jmteb/embedders/openai_embedder.py
+++ b/src/jmteb/embedders/openai_embedder.py
@@ -84,8 +84,4 @@ class OpenAIEmbedder(TextEmbedder):
     def encode_and_truncate_text(self, text: str) -> list[int]:
         # Refer to https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken
         # return a list of token IDs
-        # As encoding long text is very slow, we can truncate the raw text first to speedup
-        # In Japanese, 1 token = 0.92 tokens in average for cl100k_base (vocab of all embedding models),
-        # (source: https://zenn.dev/microsoft/articles/dcf32f3516f013)
-        # so we infer the token number of text[: max_token_len * 1.2] is very likely to be more than max_token_len.
-        return self.encoding.encode(text[: int(self.max_token_length * 1.2)])[: self.max_token_length]
+        return self.encoding.encode(text)[: self.max_token_length]

--- a/src/jmteb/embedders/openai_embedder.py
+++ b/src/jmteb/embedders/openai_embedder.py
@@ -61,9 +61,9 @@ class OpenAIEmbedder(TextEmbedder):
         kwargs = {"dimensions": self.dim} if self.model != "text-embedding-ada-002" else {}
         # specifying `dimensions` is not allowed for "text-embedding-ada-002"
         if isinstance(text, str):
-            token_ids: list[int] = self.truncate_text(text)
+            token_ids: list[int] = self.encode_and_truncate_text(text)
         else:
-            token_ids: list[list[int]] = [self.truncate_text(t) for t in text]
+            token_ids: list[list[int]] = [self.encode_and_truncate_text(t) for t in text]
         result = np.asarray(
             [
                 data.embedding
@@ -81,7 +81,7 @@ class OpenAIEmbedder(TextEmbedder):
     def get_output_dim(self) -> int:
         return self.dim
 
-    def truncate_text(self, text: str) -> list[int]:
+    def encode_and_truncate_text(self, text: str) -> list[int]:
         # Refer to https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken
         # return a list of token IDs
         # As encoding long text is very slow, we can truncate the raw text first to speedup

--- a/tests/embedders/test_openai.py
+++ b/tests/embedders/test_openai.py
@@ -72,8 +72,10 @@ class TestOpenAIEmbedder:
         assert len(self.model.encoding.encode(TEXT)) == 6
 
     def test_truncate(self):
-        assert len(self.model.truncate_text(TEXT)) == 6
-        assert len(self.model.truncate_text(TEXT * self.model.max_token_length)) == self.model.max_token_length
+        assert len(self.model.encode_and_truncate_text(TEXT)) == 6
+        assert (
+            len(self.model.encode_and_truncate_text(TEXT * self.model.max_token_length)) == self.model.max_token_length
+        )
 
     def test_nonexistent_model(self):
         with pytest.raises(AssertionError):

--- a/tests/embedders/test_openai.py
+++ b/tests/embedders/test_openai.py
@@ -81,7 +81,18 @@ class TestOpenAIEmbedder:
 
     def test_model_dim(self):
         assert OpenAIEmbedder(model="text-embedding-3-large").dim == 3072
+        assert OpenAIEmbedder(model="text-embedding-3-small").dim == 1536
         assert OpenAIEmbedder(model="text-embedding-ada-002").dim == 1536
+
+    def test_model_max_token_length(self):
+        assert OpenAIEmbedder(model="text-embedding-3-large").max_token_length == 8191
+        assert OpenAIEmbedder(model="text-embedding-3-small").max_token_length == 8191
+        assert OpenAIEmbedder(model="text-embedding-ada-002").max_token_length == 8191
+
+    def test_model_encoder(self):
+        assert OpenAIEmbedder(model="text-embedding-3-large").encoding.name == "cl100k_base"
+        assert OpenAIEmbedder(model="text-embedding-3-small").encoding.name == "cl100k_base"
+        assert OpenAIEmbedder(model="text-embedding-ada-002").encoding.name == "cl100k_base"
 
     def test_ada_002_dim(self):
         # check that no `dimensions` argument is set for model "text-embedding-ada-002"


### PR DESCRIPTION
<!-- 
PRを出していただき、ありがとうございます。
base branchを`dev`にするよう、お願いいたします。
-->

## 関連する Issue / PR
#15 

## PR をマージした後の挙動の変化
モデルの長さ制限を超えないため，長すぎるテキストは事前にtruncateします。

## 挙動の変更を達成するために行ったこと
`truncate_text`を実装し，テキストをトークンのリストに変換し，truncateする。

## 動作確認
- [x] テストが通ることを確認した

<!-- 
## その他
-->