### PR TITLE
[Fix] OpenAIEmbedderにおけるempty stringの処理

### DIFF
--- a/src/jmteb/embedders/openai_embedder.py
+++ b/src/jmteb/embedders/openai_embedder.py
@@ -38,6 +38,9 @@ class OpenAIEmbedder(TextEmbedder):
         OpenAI embeddings have been normalized to length 1. See
             https://platform.openai.com/docs/guides/embeddings/which-distance-function-should-i-use
 
+        As OpenAI embedding APIs don't allow an empty string as input, we replace an empty string with a
+            space " " to avoid error.
+
         Args:
             model (str, optional): Name of an OpenAI embedding model. Defaults to "text-embedding-3-small".
             dim (int, optional): Output dimension. Defaults to 1536.

--- a/src/jmteb/embedders/openai_embedder.py
+++ b/src/jmteb/embedders/openai_embedder.py
@@ -84,4 +84,7 @@ class OpenAIEmbedder(TextEmbedder):
     def encode_and_truncate_text(self, text: str) -> list[int]:
         # Refer to https://cookbook.openai.com/examples/how_to_count_tokens_with_tiktoken
         # return a list of token IDs
+        if not text:
+            text = " "
+            logger.warning("Found empty string!")
         return self.encoding.encode(text)[: self.max_token_length]

--- a/tests/embedders/test_openai.py
+++ b/tests/embedders/test_openai.py
@@ -31,6 +31,8 @@ class MockEmbedding:
 
 class MockOpenAIClientEmbedding:
     def create(input: str | Iterable[str] | Iterable[int] | Iterable[Iterable[int]], model: str, **kwargs):
+        if not input:
+            raise ValueError("Empty string not allowed")
         if model == "text-embedding-ada-002":
             assert "dimensions" not in kwargs
             dimensions = OUTPUT_DIM
@@ -113,3 +115,8 @@ class TestOpenAIEmbedder:
 
     def test_dim_smaller(self):
         assert OpenAIEmbedder(dim=OUTPUT_DIM // 2).dim == OUTPUT_DIM // 2
+
+    def test_empty_string(self):
+        embedder = OpenAIEmbedder()
+        # check that an empty string is replaced by " ", else a ValueError will be raised.
+        assert all(np.equal(embedder.encode(""), embedder.encode(" ")))


### PR DESCRIPTION
<!-- 
PRを出していただき、ありがとうございます。
base branchを`dev`にするよう、お願いいたします。
-->

## 関連する Issue / PR
N/A

## PR をマージした後の挙動の変化
OpenAI embedding APIにおいては，入力がempty stringではならないので，異常処理を追加します。
Empty stringを見つかったら" "(space一つ)に変えます。

## 挙動の変更を達成するために行ったこと
異常処理を追加

## 動作確認
- [x] テストが通ることを確認した

<!-- 
## その他
-->