### PR TITLE
[Feature] Support customizing `model_kwargs`

### DIFF
--- a/src/jmteb/embedders/base.py
+++ b/src/jmteb/embedders/base.py
@@ -138,6 +138,6 @@ class TextEmbedder(ABC):
         self.convert_to_numpy = False
         self.convert_to_tensor = True
 
-    def set_output_np(self):
+    def set_output_numpy(self):
         self.convert_to_numpy = True
         self.convert_to_tensor = False

--- a/src/jmteb/embedders/base.py
+++ b/src/jmteb/embedders/base.py
@@ -5,6 +5,7 @@ from os import PathLike
 from pathlib import Path
 
 import numpy as np
+import torch
 import tqdm
 from loguru import logger
 
@@ -14,7 +15,10 @@ class TextEmbedder(ABC):
     The base class of text embedder.
     """
 
-    def encode(self, text: str | list[str], prefix: str | None = None) -> np.ndarray:
+    convert_to_tensor: bool
+    convert_to_numpy: bool
+
+    def encode(self, text: str | list[str], prefix: str | None = None) -> np.ndarray | torch.Tensor:
         """Convert a text string or a list of texts to embedding.
 
         Args:
@@ -38,7 +42,7 @@ class TextEmbedder(ABC):
         prefix: str | None = None,
         batch_size: int = 64,
         dtype: str = "float32",
-    ) -> np.memmap:
+    ) -> np.memmap | torch.Tensor:
         """
         Encode a list of texts and save the embeddings on disk using memmap.
 
@@ -52,18 +56,24 @@ class TextEmbedder(ABC):
 
         num_samples = len(text_list)
         output_dim = self.get_output_dim()
-        embeddings = np.memmap(save_path, dtype=dtype, mode="w+", shape=(num_samples, output_dim))
+        if self.convert_to_numpy:
+            embeddings = np.memmap(save_path, dtype=dtype, mode="w+", shape=(num_samples, output_dim))
+        else:
+            embeddings = torch.empty((num_samples, output_dim), dtype=self._torch_dtype_parser(dtype))
 
         with tqdm.tqdm(total=num_samples, desc="Encoding") as pbar:
             for i in range(0, num_samples, batch_size):
                 batch = text_list[i : i + batch_size]
-                batch_embeddings = self.encode(batch, prefix=prefix)
-                batch_embeddings = np.asarray(batch_embeddings, dtype=dtype)
+                batch_embeddings: np.ndarray | torch.Tensor = self.encode(batch, prefix=prefix)
                 embeddings[i : i + batch_size] = batch_embeddings
                 pbar.update(len(batch))
-        embeddings.flush()
 
-        return np.memmap(save_path, dtype=dtype, mode="r", shape=(num_samples, output_dim))
+        if self.convert_to_numpy:
+            embeddings.flush()
+            return np.memmap(save_path, dtype=dtype, mode="r", shape=(num_samples, output_dim))
+        else:
+            torch.save(embeddings, save_path)
+            return embeddings
 
     def batch_encode_with_cache(
         self,
@@ -73,7 +83,7 @@ class TextEmbedder(ABC):
         overwrite_cache: bool = False,
         batch_size: int = 64,
         dtype: str = "float32",
-    ) -> np.ndarray:
+    ) -> np.ndarray | torch.Tensor:
         """
         Encode a list of texts and save the embeddings on disk using memmap if cache_path is provided.
 
@@ -88,7 +98,7 @@ class TextEmbedder(ABC):
 
         if cache_path is None:
             logger.info("Encoding embeddings")
-            return self.encode(text_list, prefix=prefix).astype(dtype)
+            return self.encode(text_list, prefix=prefix)
 
         if Path(cache_path).exists() and not overwrite_cache:
             logger.info(f"Loading embeddings from {cache_path}")
@@ -99,3 +109,35 @@ class TextEmbedder(ABC):
             text_list, cache_path, prefix=prefix, batch_size=batch_size, dtype=dtype
         )
         return embeddings
+
+    @staticmethod
+    def _torch_dtype_parser(dtype: str | torch.dtype) -> torch.dtype | str:
+        if dtype == "auto":
+            return dtype
+        elif isinstance(dtype, str):
+            dtype = dtype.replace("torch.", "")
+            if hasattr(torch, dtype):
+                dtype = getattr(torch, dtype)
+                if isinstance(dtype, torch.dtype):
+                    return dtype
+            raise ValueError(f"Invalid torch dtype: {dtype}")
+        elif isinstance(dtype, torch.dtype):
+            return dtype
+        else:
+            raise ValueError(f"Expected `dtype` as `str` or `torch.dtype`, but got {type(dtype)}!")
+
+    def _model_kwargs_parser(self, model_kwargs: dict | None) -> dict:
+        if not model_kwargs:
+            return {}
+
+        if "torch_dtype" in model_kwargs:
+            model_kwargs["torch_dtype"] = self._torch_dtype_parser(model_kwargs["torch_dtype"])
+        return model_kwargs
+
+    def set_output_tensor(self):
+        self.convert_to_numpy = False
+        self.convert_to_tensor = True
+
+    def set_output_np(self):
+        self.convert_to_numpy = True
+        self.convert_to_tensor = False

--- a/src/jmteb/embedders/openai_embedder.py
+++ b/src/jmteb/embedders/openai_embedder.py
@@ -60,6 +60,9 @@ class OpenAIEmbedder(TextEmbedder):
             else:
                 self.dim = dim
 
+        self.convert_to_tensor = False
+        self.convert_to_numpy = True
+
     def encode(self, text: str | list[str], prefix: str | None = None) -> np.ndarray:
         kwargs = {"dimensions": self.dim} if self.model != "text-embedding-ada-002" else {}
         # specifying `dimensions` is not allowed for "text-embedding-ada-002"

--- a/src/jmteb/embedders/sbert_embedder.py
+++ b/src/jmteb/embedders/sbert_embedder.py
@@ -41,7 +41,7 @@ class SentenceBertEmbedder(TextEmbedder):
         if "torch_dtype" in model_kwargs:
             self.set_output_tensor()
         else:
-            self.set_output_np()
+            self.set_output_numpy()
 
     def encode(self, text: str | list[str], prefix: str | None = None) -> np.ndarray:
         if self.add_eos:

--- a/src/jmteb/embedders/transformers_embedder.py
+++ b/src/jmteb/embedders/transformers_embedder.py
@@ -82,7 +82,7 @@ class TransformersEmbedder(TextEmbedder):
         if "torch_dtype" in model_kwargs:
             self.set_output_tensor()
         else:
-            self.set_output_np()
+            self.set_output_numpy()
 
     def get_output_dim(self) -> int:
         return self.output_dim

--- a/src/jmteb/embedders/transformers_embedder.py
+++ b/src/jmteb/embedders/transformers_embedder.py
@@ -26,9 +26,13 @@ class TransformersEmbedder(TextEmbedder):
         truncate_dim: int | None = None,
         pooling_config: str | None = "1_Pooling/config.json",
         pooling_mode: str | None = None,
+        model_kwargs: dict = {},
         tokenizer_kwargs: dict = {},
     ) -> None:
-        self.model: PreTrainedModel = AutoModel.from_pretrained(model_name_or_path, trust_remote_code=True)
+        model_kwargs = self._model_kwargs_parser(model_kwargs)
+        self.model: PreTrainedModel = AutoModel.from_pretrained(
+            model_name_or_path, trust_remote_code=True, **model_kwargs
+        )
         self.batch_size = batch_size
         if not device and torch.cuda.is_available():
             self.device = "cuda"
@@ -70,7 +74,15 @@ class TransformersEmbedder(TextEmbedder):
             include_prompt=pooling_config.get("include_prompt", True),
         )
 
-        self.output_dim = self.pooling.get_sentence_embedding_dimension()
+        if self.truncate_dim:
+            self.output_dim = min(self.pooling.get_sentence_embedding_dimension(), self.truncate_dim)
+        else:
+            self.output_dim = self.pooling.get_sentence_embedding_dimension()
+
+        if "torch_dtype" in model_kwargs:
+            self.set_output_tensor()
+        else:
+            self.set_output_np()
 
     def get_output_dim(self) -> int:
         return self.output_dim
@@ -80,11 +92,7 @@ class TransformersEmbedder(TextEmbedder):
         text: str | list[str],
         prefix: str | None = None,
         show_progress_bar: bool = True,
-        convert_to_numpy: bool = True,
-        convert_to_tensor: bool = False,
     ):
-        if not convert_to_numpy ^ convert_to_tensor:
-            raise ValueError("Exactly one of `convert_to_numy` and `convert_to_tensor` must be True")
         if isinstance(text, str):
             text = [text]
             text_was_str = True
@@ -115,7 +123,7 @@ class TransformersEmbedder(TextEmbedder):
         else:
             res = all_embeddings
 
-        if convert_to_numpy:
+        if self.convert_to_numpy:
             return res.numpy()
         else:
             return res

--- a/src/jmteb/evaluators/reranking/evaluator.py
+++ b/src/jmteb/evaluators/reranking/evaluator.py
@@ -134,8 +134,8 @@ class RerankingEvaluator(EmbeddingEvaluator):
             device = "cuda" if torch.cuda.is_available() else "cpu"
             reranked_docs_list = []
             for i, item in enumerate(query_dataset):
-                query_embedding = convert_to_tensor(query_embeddings[i], device=device)
-                doc_embedding = convert_to_tensor(
+                query_embedding = to_tensor(query_embeddings[i], device=device)
+                doc_embedding = to_tensor(
                     torch.stack([doc_embeddings[doc_indices[retrieved_doc]] for retrieved_doc in item.retrieved_docs]),
                     device=device,
                 )
@@ -180,7 +180,7 @@ def ndcg_at_k(
     return total_ndcg_scores / len(retrieved_docs_list)
 
 
-def convert_to_tensor(embeddings: np.ndarray | Tensor, device: str) -> Tensor:
+def to_tensor(embeddings: np.ndarray | Tensor, device: str) -> Tensor:
     if not isinstance(embeddings, Tensor):
         embeddings = torch.tensor(embeddings)
     if len(embeddings.shape) == 1:

--- a/src/jmteb/evaluators/retrieval/evaluator.py
+++ b/src/jmteb/evaluators/retrieval/evaluator.py
@@ -147,8 +147,8 @@ class RetrievalEvaluator(EmbeddingEvaluator):
                 doc_embeddings_chunk = doc_embeddings[offset : offset + self.doc_chunk_size]
 
                 device = "cuda" if torch.cuda.is_available() else "cpu"
-                query_embeddings = convert_to_tensor(query_embeddings, device=device)
-                doc_embeddings_chunk = convert_to_tensor(doc_embeddings_chunk, device=device)
+                query_embeddings = to_tensor(query_embeddings, device=device)
+                doc_embeddings_chunk = to_tensor(doc_embeddings_chunk, device=device)
                 similarity = dist_func(query_embeddings, doc_embeddings_chunk)
 
                 top_k = min(self.max_top_k, similarity.shape[1])  # in case the corpus is smaller than max_top_k
@@ -229,7 +229,7 @@ def ndcg_at_k(relevant_docs: list[list[T]], top_hits: list[list[T]], k: int) -> 
     return total_ndcg_scores / len(relevant_docs)
 
 
-def convert_to_tensor(embeddings: np.ndarray | Tensor, device: str) -> Tensor:
+def to_tensor(embeddings: np.ndarray | Tensor, device: str) -> Tensor:
     if not isinstance(embeddings, Tensor):
         embeddings = torch.tensor(embeddings)
     if len(embeddings.shape) == 1:

--- a/src/jmteb/evaluators/retrieval/evaluator.py
+++ b/src/jmteb/evaluators/retrieval/evaluator.py
@@ -66,6 +66,7 @@ class RetrievalEvaluator(EmbeddingEvaluator):
         cache_dir: str | PathLike[str] | None = None,
         overwrite_cache: bool = False,
     ) -> EvaluationResults:
+        model.set_output_tensor()
         if cache_dir is not None:
             Path(cache_dir).mkdir(parents=True, exist_ok=True)
 
@@ -133,8 +134,8 @@ class RetrievalEvaluator(EmbeddingEvaluator):
     def _compute_metrics(
         self,
         query_dataset: RetrievalQueryDataset,
-        query_embeddings: np.ndarray,
-        doc_embeddings: np.ndarray,
+        query_embeddings: np.ndarray | Tensor,
+        doc_embeddings: np.ndarray | Tensor,
         dist_func: Callable[[Tensor, Tensor], Tensor],
     ) -> dict[str, dict[str, float]]:
         results: dict[str, float] = {}

--- a/src/jmteb/evaluators/sts/evaluator.py
+++ b/src/jmteb/evaluators/sts/evaluator.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
 import math
+from dataclasses import dataclass
 from os import PathLike
 from pathlib import Path
 from typing import Callable

--- a/src/jmteb/evaluators/sts/evaluator.py
+++ b/src/jmteb/evaluators/sts/evaluator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
 from os import PathLike
 from pathlib import Path
 from typing import Callable
@@ -103,9 +104,11 @@ class STSEvaluator(EmbeddingEvaluator):
         embeddings1: Tensor, embeddings2: Tensor, golden_scores: list, similarity_func: Callable
     ) -> dict[str, float]:
         test_sim_score = similarity_func(embeddings1, embeddings2).cpu()
+        pearson = pearsonr(golden_scores, test_sim_score)[0]
+        spearman = spearmanr(golden_scores, test_sim_score)[0]
         return {
-            "pearson": pearsonr(golden_scores, test_sim_score)[0],
-            "spearman": spearmanr(golden_scores, test_sim_score)[0],
+            "pearson": pearson if not math.isnan(pearson) else 0.0,
+            "spearman": spearman if not math.isnan(spearman) else 0.0,
         }
 
     def _convert_to_embeddings(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,11 @@ def pytest_collection_modifyitems(config: pytest.Config, items: pytest.Parser):
 
 
 class DummyTextEmbedder(TextEmbedder):
+    def __init__(self, model_kwargs: dict | None = None) -> None:
+        self.model_kwargs = self._model_kwargs_parser(model_kwargs)
+        self.convert_to_tensor = self.model_kwargs.get("torch_dtype", None) is None
+        self.convert_to_numpy = not self.convert_to_tensor
+
     def encode(self, text: str | list[str], prefix: str | None = None) -> np.ndarray:
         if isinstance(text, str):
             batch_size = 1

--- a/tests/embedders/test_sbert.py
+++ b/tests/embedders/test_sbert.py
@@ -28,3 +28,9 @@ class TestSentenceBertEmbedder:
         model = SentenceBertEmbedder(MODEL_NAME_OR_PATH, model_kwargs={"torch_dtype": torch.float16})
         assert model.convert_to_tensor
         assert model.encode("任意のテキスト").dtype is torch.float16
+
+    def test_bf16(self):
+        # As numpy doesn't support native bfloat16, add a test case for bf16
+        model = SentenceBertEmbedder(MODEL_NAME_OR_PATH, model_kwargs={"torch_dtype": torch.bfloat16})
+        assert model.convert_to_tensor
+        assert model.encode("任意のテキスト").dtype is torch.bfloat16

--- a/tests/embedders/test_sbert.py
+++ b/tests/embedders/test_sbert.py
@@ -1,4 +1,5 @@
 import numpy as np
+import torch
 
 from jmteb.embedders.sbert_embedder import SentenceBertEmbedder
 
@@ -22,3 +23,8 @@ class TestSentenceBertEmbedder:
         assert self.model.model.tokenizer.sep_token == "[SEP]"
         model = SentenceBertEmbedder(MODEL_NAME_OR_PATH, tokenizer_kwargs={"sep_token": "<sep>"})
         assert model.model.tokenizer.sep_token == "<sep>"
+
+    def test_model_kwargs(self):
+        model = SentenceBertEmbedder(MODEL_NAME_OR_PATH, model_kwargs={"torch_dtype": torch.float16})
+        assert model.convert_to_tensor
+        assert model.encode("任意のテキスト").dtype is torch.float16

--- a/tests/embedders/test_transformers.py
+++ b/tests/embedders/test_transformers.py
@@ -33,3 +33,9 @@ class TestTransformersEmbedder:
         model = TransformersEmbedder(MODEL_NAME_OR_PATH, model_kwargs={"torch_dtype": torch.float16})
         assert model.convert_to_tensor
         assert model.encode("任意のテキスト").dtype is torch.float16
+
+    def test_bf16(self):
+        # As numpy doesn't support native bfloat16, add a test case for bf16
+        model = TransformersEmbedder(MODEL_NAME_OR_PATH, model_kwargs={"torch_dtype": torch.bfloat16})
+        assert model.convert_to_tensor
+        assert model.encode("任意のテキスト").dtype is torch.bfloat16

--- a/tests/embedders/test_transformers.py
+++ b/tests/embedders/test_transformers.py
@@ -1,4 +1,5 @@
 import numpy as np
+import torch
 
 from jmteb.embedders.transformers_embedder import TransformersEmbedder
 
@@ -27,3 +28,8 @@ class TestTransformersEmbedder:
         assert self.model.tokenizer.sep_token == "[SEP]"
         model = TransformersEmbedder(MODEL_NAME_OR_PATH, tokenizer_kwargs={"sep_token": "<sep>"})
         assert model.tokenizer.sep_token == "<sep>"
+
+    def test_model_kwargs(self):
+        model = TransformersEmbedder(MODEL_NAME_OR_PATH, model_kwargs={"torch_dtype": torch.float16})
+        assert model.convert_to_tensor
+        assert model.encode("任意のテキスト").dtype is torch.float16

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -23,6 +23,7 @@ def test_main_cli():
         command = [
             "python", "-m", "jmteb",
             "--embedder", "tests.conftest.DummyTextEmbedder",
+            "--embedder.model_kwargs", '{"torch_dtype": "torch.float16"}',
             "--save_dir", f,
             "--eval_include", '["jsts"]',
         ]


### PR DESCRIPTION
<!-- 
PRを出していただき、ありがとうございます。
base branchを`dev`にするよう、お願いいたします。
-->

## 関連する Issue / PR
#39 

## PR をマージした後の挙動の変化
* `TextEmbedder`に出力型flag (sentence transformersに倣って`convert_to_tensor`, `convert_to_numpy`)をメンバーに入れる
* モデルを初期化する際に`model_kwargs`を設定できるようになった
* `jsonargparse`対応のため，`model_kwargs`引数を読み込む関数を作成
* minor fixes
* テストケースを追加

## 挙動の変更を達成するために行ったこと
* `TextEmbedder`に出力型flag (sentence transformersに倣って`convert_to_tensor`, `convert_to_numpy`)をメンバーに入れる
* モデルを初期化する際に`model_kwargs`設定（特に推論時のdtype，そのための読み込み関数を作成）を読み込む
* 後処理に`torch.Tensor`型使用のシナリオ（検索とreranking），`Tensor`→`ndarray`→`Tensor`の変換をやめて，`Tensor`そのまま出力させる
* `torch.float16`を指定する際の動作確認をテストケースとして追加する

## 動作確認
- [x] テストが通ることを確認した
- [x] マージ先がdevブランチであることを確認した

<!-- 
## その他
-->