### PR TITLE
[Fix] STSにおいてbfloat16 tensorが起こった不具合

### DIFF
--- a/src/jmteb/evaluators/sts/evaluator.py
+++ b/src/jmteb/evaluators/sts/evaluator.py
@@ -109,6 +109,8 @@ class STSEvaluator(EmbeddingEvaluator):
         embeddings1: Tensor, embeddings2: Tensor, golden_scores: list, similarity_func: Callable
     ) -> tuple[dict[str, float], list[float]]:
         sim_scores = similarity_func(embeddings1, embeddings2).cpu()
+        if isinstance(sim_scores, Tensor) and sim_scores.dtype is torch.bfloat16:
+            sim_scores = sim_scores.float()
         pearson = pearsonr(golden_scores, sim_scores)[0]
         spearman = spearmanr(golden_scores, sim_scores)[0]
         return {


### PR DESCRIPTION
<!-- 
PRを出していただき、ありがとうございます。
base branchを`dev`にするよう、お願いいたします。
-->

## 関連する Issue / PR
N/A

## PR をマージした後の挙動の変化
STSに`scipy`の関数を使っており，その内部に`tensor.numpy()`の処理があり，`tensor`が`torch.bfloat16`タイプの場合，不具合が起こります。
```
[rank2]:   File "~/JMTEB/src/jmteb/evaluators/sts/evaluator.py", line 74, in __call__
[rank2]:     val_results[sim_name], _ = self._compute_similarity(
[rank2]:   File "~/JMTEB/src/jmteb/evaluators/sts/evaluator.py", line 112, in _compute_similarity
[rank2]:     pearson = pearsonr(golden_scores, sim_scores)[0]
[rank2]:   File "/usr/local/lib/python3.10/dist-packages/scipy/stats/_stats_py.py", line 4727, in pearsonr
[rank2]:     y = np.asarray(y)
[rank2]:   File "/usr/local/lib/python3.10/dist-packages/torch/_tensor.py", line 1087, in __array__
[rank2]:     return self.numpy()
[rank2]: TypeError: Got unsupported ScalarType BFloat16
```

## 挙動の変更を達成するために行ったこと
`sim_scores`が`torch.bfloat16`である場合，`.float()`の`dtype`変更

## 動作確認
- [x] テストが通ることを確認した
- [x] マージ先がdevブランチであることを確認した

<!-- 
## その他
-->