### PR TITLE
[Fix] multi-GPU rerank retrievalタスクにおいてOOM防止のための修正

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     env:
-      PYTHON_VERSION: "3.9"
+      PYTHON_VERSION: "3.10"
       NO_CACHE: ${{ github.event.inputs.no-cache || 'false' }}
     steps:
       - name: Checkout
@@ -53,7 +53,7 @@ jobs:
   lint_check:
     runs-on: ubuntu-latest
     env:
-      PYTHON_VERSION: "3.9"
+      PYTHON_VERSION: "3.10"
     steps:
       - uses: actions/checkout@v3
 

--- a/src/jmteb/configs/tasks/mrtydi.jsonnet
+++ b/src/jmteb/configs/tasks/mrtydi.jsonnet
@@ -26,6 +26,7 @@
           name: 'mrtydi-corpus',
         },
       },
+      "doc_chunk_size":10000
     },
   },
 }

--- a/src/jmteb/evaluators/reranking/evaluator.py
+++ b/src/jmteb/evaluators/reranking/evaluator.py
@@ -150,7 +150,6 @@ class RerankingEvaluator(EmbeddingEvaluator):
         results: dict[str, float] = {}
 
         with tqdm.tqdm(total=len(query_dataset), desc="Reranking docs") as pbar:
-
             if torch.cuda.is_available():
                 if dist.is_available():
                     device = f"cuda:{dist.get_rank()}"

--- a/src/jmteb/evaluators/reranking/evaluator.py
+++ b/src/jmteb/evaluators/reranking/evaluator.py
@@ -7,10 +7,10 @@ from typing import Callable, TypeVar
 
 import numpy as np
 import torch
-from torch import distributed as dist
 import tqdm
 from loguru import logger
 from torch import Tensor
+from torch import distributed as dist
 
 from jmteb.embedders.base import TextEmbedder
 from jmteb.evaluators.base import EmbeddingEvaluator, EvaluationResults
@@ -150,14 +150,14 @@ class RerankingEvaluator(EmbeddingEvaluator):
         results: dict[str, float] = {}
 
         with tqdm.tqdm(total=len(query_dataset), desc="Reranking docs") as pbar:
-            
+
             if torch.cuda.is_available():
                 if dist.is_available():
-                    device = f'cuda:{dist.get_rank()}'
+                    device = f"cuda:{dist.get_rank()}"
                 else:
-                    device = 'cuda'
+                    device = "cuda"
             else:
-                device = 'cpu'
+                device = "cpu"
             reranked_docs_list = []
             for i, item in enumerate(query_dataset):
                 query_embedding = to_tensor(query_embeddings[i], device=device)

--- a/src/jmteb/evaluators/retrieval/evaluator.py
+++ b/src/jmteb/evaluators/retrieval/evaluator.py
@@ -11,6 +11,7 @@ import torch
 import tqdm
 from loguru import logger
 from torch import Tensor
+from torch import distributed as dist
 
 from jmteb.embedders.base import TextEmbedder
 from jmteb.evaluators.base import EmbeddingEvaluator, EvaluationResults
@@ -158,7 +159,14 @@ class RetrievalEvaluator(EmbeddingEvaluator):
             for offset in range(0, len(doc_embeddings), self.doc_chunk_size):
                 doc_embeddings_chunk = doc_embeddings[offset : offset + self.doc_chunk_size]
 
-                device = "cuda" if torch.cuda.is_available() else "cpu"
+                if torch.cuda.is_available():
+                    if dist.is_available():
+                        device = f'cuda:{dist.get_rank()}'
+                    else:
+                        device = 'cuda'
+                else:
+                    device = 'cpu'
+
                 query_embeddings = to_tensor(query_embeddings, device=device)
                 doc_embeddings_chunk = to_tensor(doc_embeddings_chunk, device=device)
                 similarity = dist_func(query_embeddings, doc_embeddings_chunk)

--- a/src/jmteb/evaluators/retrieval/evaluator.py
+++ b/src/jmteb/evaluators/retrieval/evaluator.py
@@ -161,11 +161,11 @@ class RetrievalEvaluator(EmbeddingEvaluator):
 
                 if torch.cuda.is_available():
                     if dist.is_available():
-                        device = f'cuda:{dist.get_rank()}'
+                        device = f"cuda:{dist.get_rank()}"
                     else:
-                        device = 'cuda'
+                        device = "cuda"
                 else:
-                    device = 'cpu'
+                    device = "cpu"
 
                 query_embeddings = to_tensor(query_embeddings, device=device)
                 doc_embeddings_chunk = to_tensor(doc_embeddings_chunk, device=device)


### PR DESCRIPTION
<!-- 
PRを出していただき、ありがとうございます。
base branchを`dev`にするよう、お願いいたします。
-->

## 関連する Issue / PR
<!-- 
関連する Issue へのリンクを貼り付けてください
-->
https://github.com/sbintuitions/JMTEB/issues/50

## PR をマージした後の挙動の変化
<!-- 
この PR により達成したい事柄を簡潔に記載してください。
-->
- 緊急のdebugとして、TransfomersEmbedderで複数GPUを使った場合のOOMを防ぐ

## 挙動の変更を達成するために行ったこと
<!-- 
実装方針/内容の概略を記載してください
-->
- (緊急のdebugとして) torchrunのそれぞれのプロセスで、異なるGPUで類似度行列の計算を行う
- 類似度行列のchunk sizeを1000000→10000に変更

## 動作確認
- [x] テストが通ることを確認した
- [x] マージ先がdevブランチであることを確認した

<!-- 
## その他
-->