### PR TITLE
[Fix] 予測値をjsonlに保存

### DIFF
--- a/src/jmteb/__main__.py
+++ b/src/jmteb/__main__.py
@@ -37,6 +37,10 @@ def main(
             dataset_name=eval_name,
             task_name=evaluator.__class__.__name__.replace("Evaluator", ""),
         )
+        if getattr(evaluator, "log_predictions", False):
+            score_recorder.record_predictions(
+                metrics, eval_name, evaluator.__class__.__name__.replace("Evaluator", "")
+            )
 
         logger.info(f"Results for {eval_name}\n{json.dumps(metrics.as_dict(), indent=4, ensure_ascii=False)}")
 

--- a/src/jmteb/utils/score_recorder.py
+++ b/src/jmteb/utils/score_recorder.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from dataclasses import asdict
 import json
 from abc import ABC, abstractmethod
 from collections import defaultdict
+from dataclasses import asdict
 from os import PathLike
 from pathlib import Path
 from typing import Any


### PR DESCRIPTION
<!-- 
PRを出していただき、ありがとうございます。
base branchを`dev`にするよう、お願いいたします。
-->

## 関連する Issue / PR
#43 #42 

## PR をマージした後の挙動の変化
予測値をjsonlに保存する

## 挙動の変更を達成するために行ったこと
* `JsonScoreRecorder`に保存用の関数を追加
* `main`に保存するための操作を行う

## 動作確認
- [x] テストが通ることを確認した
- [x] マージ先がdevブランチであることを確認した

<!-- 
## その他
-->