### PR TITLE
[Feature] Allow setting encode kwargs in SentenceBert embedder

### DIFF
--- a/src/jmteb/embedders/base.py
+++ b/src/jmteb/embedders/base.py
@@ -25,6 +25,7 @@ class TextEmbedder(ABC):
         Args:
             text (str | list[str]): text string, or a list of texts.
             prefix (str, optional): the prefix to use for encoding. Default to None.
+            **kwargs: some more settings that may be necessary for specific models.
         """
         raise NotImplementedError
 

--- a/src/jmteb/embedders/sbert_embedder.py
+++ b/src/jmteb/embedders/sbert_embedder.py
@@ -43,7 +43,7 @@ class SentenceBertEmbedder(TextEmbedder):
         else:
             self.set_output_numpy()
 
-    def encode(self, text: str | list[str], prefix: str | None = None) -> np.ndarray:
+    def encode(self, text: str | list[str], prefix: str | None = None, **kwargs) -> np.ndarray:
         if self.add_eos:
             text = self._add_eos_func(text)
         return self.model.encode(
@@ -54,6 +54,7 @@ class SentenceBertEmbedder(TextEmbedder):
             batch_size=self.batch_size,
             device=self.device,
             normalize_embeddings=self.normalize_embeddings,
+            **kwargs,
         )
 
     def _add_eos_func(self, text: str | list[str]) -> str | list[str]:

--- a/src/jmteb/evaluators/classification/evaluator.py
+++ b/src/jmteb/evaluators/classification/evaluator.py
@@ -40,6 +40,7 @@ class ClassificationEvaluator(EmbeddingEvaluator):
         classifiers: dict[str, Classifier] | None = None,
         prefix: str | None = None,
         log_predictions: bool = False,
+        encode_kwargs: dict = {},
     ) -> None:
         self.train_dataset = train_dataset
         self.val_dataset = val_dataset
@@ -55,6 +56,7 @@ class ClassificationEvaluator(EmbeddingEvaluator):
         ] or ["macro"]
         self.prefix = prefix
         self.log_predictions = log_predictions
+        self.encode_kwargs = encode_kwargs
         self.main_metric = f"{self.average[0]}_f1"
 
     def __call__(
@@ -69,6 +71,7 @@ class ClassificationEvaluator(EmbeddingEvaluator):
             prefix=self.prefix,
             cache_path=Path(cache_dir) / "train_embeddings.bin" if cache_dir is not None else None,
             overwrite_cache=overwrite_cache,
+            **self.encode_kwargs,
         )
         y_train = [item.label for item in self.train_dataset]
 
@@ -77,6 +80,7 @@ class ClassificationEvaluator(EmbeddingEvaluator):
             prefix=self.prefix,
             cache_path=Path(cache_dir) / "val_embeddings.bin" if cache_dir is not None else None,
             overwrite_cache=overwrite_cache,
+            **self.encode_kwargs,
         )
         y_val = [item.label for item in self.val_dataset]
 
@@ -90,6 +94,7 @@ class ClassificationEvaluator(EmbeddingEvaluator):
                 prefix=self.prefix,
                 cache_path=Path(cache_dir) / "test_embeddings.bin" if cache_dir is not None else None,
                 overwrite_cache=overwrite_cache,
+                **self.encode_kwargs,
             )
             y_test = [item.label for item in self.test_dataset]
 

--- a/src/jmteb/evaluators/classification/evaluator.py
+++ b/src/jmteb/evaluators/classification/evaluator.py
@@ -29,6 +29,7 @@ class ClassificationEvaluator(EmbeddingEvaluator):
         classifiers (dict[str, Classifier]): classifiers to be evaluated.
         prefix (str | None): prefix for sentences. Defaults to None.
         log_predictions (bool): whether to log predictions of each datapoint.
+        encode_kwargs (dict): kwargs passed to embedder's encode function. Defaults to {}.
     """
 
     def __init__(

--- a/src/jmteb/evaluators/clustering/evaluator.py
+++ b/src/jmteb/evaluators/clustering/evaluator.py
@@ -33,12 +33,14 @@ class ClusteringEvaluator(EmbeddingEvaluator):
         prefix: str | None = None,
         random_seed: int | None = None,
         log_predictions: bool = False,
+        encode_kwargs: dict = {},
     ) -> None:
         self.val_dataset = val_dataset
         self.test_dataset = test_dataset
         self.prefix = prefix
         self.random_seed = random_seed
         self.log_predictions = log_predictions
+        self.encode_kwargs = encode_kwargs
         self.main_metric = "v_measure_score"
 
     def __call__(
@@ -53,6 +55,7 @@ class ClusteringEvaluator(EmbeddingEvaluator):
             prefix=self.prefix,
             cache_path=Path(cache_dir) / "val_embeddings.bin" if cache_dir is not None else None,
             overwrite_cache=overwrite_cache,
+            **self.encode_kwargs,
         )
         val_labels = [item.label for item in self.val_dataset]
 
@@ -66,6 +69,7 @@ class ClusteringEvaluator(EmbeddingEvaluator):
                 prefix=self.prefix,
                 cache_path=Path(cache_dir) / "test_embeddings.bin" if cache_dir is not None else None,
                 overwrite_cache=overwrite_cache,
+                **self.encode_kwargs,
             )
             test_labels = [item.label for item in self.test_dataset]
 

--- a/src/jmteb/evaluators/clustering/evaluator.py
+++ b/src/jmteb/evaluators/clustering/evaluator.py
@@ -24,6 +24,14 @@ from .data import ClusteringDataset, ClusteringPrediction
 class ClusteringEvaluator(EmbeddingEvaluator):
     """
     ClusteringEvaluator is a class for evaluating clustering models.
+
+    Args:
+        val_dataset (ClusteringDataset): validation dataset
+        test_dataset (ClusteringDataset): evaluation dataset
+        prefix (str | None): prefix for sentences. Defaults to None.
+        random_seed (int | None): random seed used in clustering models. Defaults to None.
+        log_predictions (bool): whether to log predictions of each datapoint.
+        encode_kwargs (dict): kwargs passed to embedder's encode function. Defaults to {}.
     """
 
     def __init__(

--- a/src/jmteb/evaluators/pair_classification/evaluator.py
+++ b/src/jmteb/evaluators/pair_classification/evaluator.py
@@ -22,6 +22,7 @@ class PairClassificationEvaluator(EmbeddingEvaluator):
         test_dataset (PairClassificationDataset): test dataset
         sentence1_prefix (str | None): prefix for sentence1. Defaults to None.
         sentence2_prefix (str | None): prefix for sentence2. Defaults to None.
+        encode_kwargs (dict): kwargs passed to embedder's encode function. Default to {}.
 
     # NOTE: Don't log predictions, as predictions by different metrics could be different.
     """

--- a/src/jmteb/evaluators/pair_classification/evaluator.py
+++ b/src/jmteb/evaluators/pair_classification/evaluator.py
@@ -32,11 +32,13 @@ class PairClassificationEvaluator(EmbeddingEvaluator):
         test_dataset: PairClassificationDataset,
         sentence1_prefix: str | None = None,
         sentence2_prefix: str | None = None,
+        encode_kwargs: dict = {},
     ) -> None:
         self.test_dataset = test_dataset
         self.val_dataset = val_dataset
         self.sentence1_prefix = sentence1_prefix
         self.sentence2_prefix = sentence2_prefix
+        self.encode_kwargs = encode_kwargs
         self.metrics = [ThresholdAccuracyMetric(), ThresholdF1Metric()]
         self.main_metric = "binary_f1"
 
@@ -122,12 +124,14 @@ class PairClassificationEvaluator(EmbeddingEvaluator):
             prefix=self.sentence1_prefix,
             cache_path=Path(cache_dir) / f"{split}_embeddings1.bin" if cache_dir is not None else None,
             overwrite_cache=overwrite_cache,
+            **self.encode_kwargs,
         )
         embeddings2 = model.batch_encode_with_cache(
             [item.sentence2 for item in dataset],
             prefix=self.sentence2_prefix,
             cache_path=Path(cache_dir) / f"{split}_embeddings2.bin" if cache_dir is not None else None,
             overwrite_cache=overwrite_cache,
+            **self.encode_kwargs,
         )
         golden_labels = [item.label for item in dataset]
         return embeddings1, embeddings2, golden_labels

--- a/src/jmteb/evaluators/reranking/evaluator.py
+++ b/src/jmteb/evaluators/reranking/evaluator.py
@@ -39,6 +39,8 @@ class RerankingEvaluator(EmbeddingEvaluator):
         doc_prefix (str | None): prefix for documents. Defaults to None.
         log_predictions (bool): whether to log predictions of each datapoint. Defaults to False.
         top_n_docs_to_log (int): log only top n documents. Defaults to 5.
+        query_encode_kwargs (dict): kwargs passed to embedder's encode function when encoding queries. Defaults to {}.
+        doc_encode_kwargs (dict): kwargs passed to embedder's encode function when encoding documents. Defaults to {}.
     """
 
     def __init__(

--- a/src/jmteb/evaluators/reranking/evaluator.py
+++ b/src/jmteb/evaluators/reranking/evaluator.py
@@ -51,6 +51,8 @@ class RerankingEvaluator(EmbeddingEvaluator):
         doc_prefix: str | None = None,
         log_predictions: bool = False,
         top_n_docs_to_log: int = 5,
+        query_encode_kwargs: dict = {},
+        doc_encode_kwargs: dict = {},
     ) -> None:
         self.test_query_dataset = test_query_dataset
         self.val_query_dataset = val_query_dataset
@@ -61,6 +63,8 @@ class RerankingEvaluator(EmbeddingEvaluator):
         self.doc_prefix = doc_prefix
         self.log_predictions = log_predictions
         self.top_n_docs_to_log = top_n_docs_to_log
+        self.query_encode_kwargs = query_encode_kwargs
+        self.doc_encode_kwargs = doc_encode_kwargs
 
     def __call__(
         self,
@@ -77,6 +81,7 @@ class RerankingEvaluator(EmbeddingEvaluator):
             prefix=self.query_prefix,
             cache_path=Path(cache_dir) / "val_query.bin" if cache_dir is not None else None,
             overwrite_cache=overwrite_cache,
+            **self.query_encode_kwargs,
         )
         if self.val_query_dataset == self.test_query_dataset:
             test_query_embeddings = val_query_embeddings
@@ -86,12 +91,14 @@ class RerankingEvaluator(EmbeddingEvaluator):
                 prefix=self.query_prefix,
                 cache_path=Path(cache_dir) / "test_query.bin" if cache_dir is not None else None,
                 overwrite_cache=overwrite_cache,
+                **self.query_encode_kwargs,
             )
         doc_embeddings = model.batch_encode_with_cache(
             text_list=[item.text for item in self.doc_dataset],
             prefix=self.doc_prefix,
             cache_path=Path(cache_dir) / "corpus.bin" if cache_dir is not None else None,
             overwrite_cache=overwrite_cache,
+            **self.doc_encode_kwargs,
         )
 
         logger.info("Start reranking")

--- a/src/jmteb/evaluators/retrieval/evaluator.py
+++ b/src/jmteb/evaluators/retrieval/evaluator.py
@@ -42,6 +42,8 @@ class RetrievalEvaluator(EmbeddingEvaluator):
         doc_prefix (str | None): prefix for documents. Defaults to None.
         log_predictions (bool): whether to log predictions of each datapoint. Defaults to False.
         top_n_docs_to_log (int): log only top n documents that are predicted as relevant. Defaults to 5.
+        query_encode_kwargs (dict): kwargs passed to embedder's encode function when encoding queries. Defaults to {}.
+        doc_encode_kwargs (dict): kwargs passed to embedder's encode function when encoding documents. Defaults to {}.
     """
 
     def __init__(

--- a/src/jmteb/evaluators/retrieval/evaluator.py
+++ b/src/jmteb/evaluators/retrieval/evaluator.py
@@ -56,6 +56,8 @@ class RetrievalEvaluator(EmbeddingEvaluator):
         doc_prefix: str | None = None,
         log_predictions: bool = False,
         top_n_docs_to_log: int = 5,
+        query_encode_kwargs: dict = {},
+        doc_encode_kwargs: dict = {},
     ) -> None:
         self.val_query_dataset = val_query_dataset
         self.test_query_dataset = test_query_dataset
@@ -72,6 +74,8 @@ class RetrievalEvaluator(EmbeddingEvaluator):
         self.doc_prefix = doc_prefix
         self.log_predictions = log_predictions
         self.top_n_docs_to_log = top_n_docs_to_log
+        self.query_encode_kwargs = query_encode_kwargs
+        self.doc_encode_kwargs = doc_encode_kwargs
 
     def __call__(
         self,
@@ -88,6 +92,7 @@ class RetrievalEvaluator(EmbeddingEvaluator):
             prefix=self.query_prefix,
             cache_path=Path(cache_dir) / "val_query.bin" if cache_dir is not None else None,
             overwrite_cache=overwrite_cache,
+            **self.query_encode_kwargs,
         )
         if self.val_query_dataset == self.test_query_dataset:
             test_query_embeddings = val_query_embeddings
@@ -97,6 +102,7 @@ class RetrievalEvaluator(EmbeddingEvaluator):
                 prefix=self.query_prefix,
                 cache_path=Path(cache_dir) / "test_query.bin" if cache_dir is not None else None,
                 overwrite_cache=overwrite_cache,
+                **self.query_encode_kwargs,
             )
 
         doc_embeddings = model.batch_encode_with_cache(
@@ -104,6 +110,7 @@ class RetrievalEvaluator(EmbeddingEvaluator):
             prefix=self.doc_prefix,
             cache_path=Path(cache_dir) / "corpus.bin" if cache_dir is not None else None,
             overwrite_cache=overwrite_cache,
+            **self.doc_encode_kwargs,
         )
 
         logger.info("Start retrieval")

--- a/src/jmteb/evaluators/sts/evaluator.py
+++ b/src/jmteb/evaluators/sts/evaluator.py
@@ -26,6 +26,7 @@ class STSEvaluator(EmbeddingEvaluator):
         test_dataset (STSDataset): test dataset
         sentence1_prefix (str | None): prefix for sentence1. Defaults to None.
         sentence2_prefix (str | None): prefix for sentence2. Defaults to None.
+        encode_kwargs (dict): kwargs passed to embedder's encode function. Defaults to {}.
     """
 
     def __init__(

--- a/src/jmteb/evaluators/sts/evaluator.py
+++ b/src/jmteb/evaluators/sts/evaluator.py
@@ -35,6 +35,7 @@ class STSEvaluator(EmbeddingEvaluator):
         sentence1_prefix: str | None = None,
         sentence2_prefix: str | None = None,
         log_predictions: bool = False,
+        encode_kwargs: dict = {},
     ) -> None:
         self.val_dataset = val_dataset
         self.test_dataset = test_dataset
@@ -42,6 +43,7 @@ class STSEvaluator(EmbeddingEvaluator):
         self.sentence2_prefix = sentence2_prefix
         self.main_metric = "spearman"
         self.log_predictions = log_predictions
+        self.encode_kwargs = encode_kwargs
 
     def __call__(
         self, model: TextEmbedder, cache_dir: str | PathLike[str] | None = None, overwrite_cache: bool = False
@@ -149,12 +151,14 @@ class STSEvaluator(EmbeddingEvaluator):
             prefix=self.sentence1_prefix,
             cache_path=Path(cache_dir) / f"{split}_embeddings1.bin" if cache_dir is not None else None,
             overwrite_cache=overwrite_cache,
+            **self.encode_kwargs,
         )
         embeddings2 = model.batch_encode_with_cache(
             [item.sentence2 for item in dataset],
             prefix=self.sentence2_prefix,
             cache_path=Path(cache_dir) / f"{split}_embeddings2.bin" if cache_dir is not None else None,
             overwrite_cache=overwrite_cache,
+            **self.encode_kwargs,
         )
         device = "cuda" if torch.cuda.is_available() else "cpu"
         embeddings1 = convert_to_tensor(embeddings1, device)


### PR DESCRIPTION
<!-- 
PRを出していただき、ありがとうございます。
base branchを`dev`にするよう、お願いいたします。
-->

## 関連する Issue / PR
#77 

## PR をマージした後の挙動の変化
encode時に独自な引数が必要な場合を対応

## 挙動の変更を達成するために行ったこと
* embedderのencode関数に`encode_kwargs`を追加
* 各タスクのevaluatorも`encode_kwargs`引数対応

## 動作確認
- [x] テストが通ることを確認した
- [x] マージ先がdevブランチであることを確認した

<!-- 
## その他
-->
